### PR TITLE
Feat: 레이아웃 구현

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -12,62 +12,71 @@ interface HeaderProps {
 // 6. 백버튼 | 제　목 | 생성버튼
 
 export default function Header({ type, title }: HeaderProps) {
+  const renderContent = () => {
+    switch (type) {
+      case 1:
+        return (
+          <>
+            <div className="w-6" />
+            <h1 className="text-lg font-semibold">{title}</h1>
+            <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 닫기 */}
+          </>
+        );
+      case 2:
+        return (
+          <>
+            <h1 className="text-lg font-semibold">{title}</h1>
+            <div className="flex gap-2">
+              <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 공유 */}
+              <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 매물 추가 */}
+            </div>
+          </>
+        );
+      case 3:
+        return (
+          <>
+            <h1 className="text-lg font-semibold">{title}</h1>
+            <div className="flex gap-2">
+              <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 공유 */}
+              <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 케밥 */}
+            </div>
+          </>
+        );
+      case 4:
+        return (
+          <>
+            <div className="flex items-center gap-2">
+              <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 뒤로가기 */}
+              <h1 className="text-lg font-semibold">{title}</h1>
+            </div>
+            <div className="w-6" />
+          </>
+        );
+      case 5:
+        return (
+          <>
+            <h1 className="text-lg font-semibold">{title}</h1>
+            <div className="w-6" />
+          </>
+        );
+      case 6:
+        return (
+          <>
+            <div className="flex items-center gap-2">
+              <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 뒤로가기 */}
+              <h1 className="text-lg font-semibold">{title}</h1>
+            </div>
+            <div className="w-auto h-6 bg-gray-300 rounded cursor-pointer">생성</div>
+          </>
+        );
+      default:
+        return <h1 className="text-lg font-semibold">{title}</h1>;
+    }
+  };
+
   return (
     <header className="flex items-center justify-between px-5 py-2 bg-white shadow-[inset_1px_0_#eee,inset_-1px_0_#eee]">
-      {type === 1 && (
-        <>
-          <div className="w-6" />
-          <h1 className="text-lg font-semibold">{title}</h1>
-          <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 닫기 */}
-        </>
-      )}
-
-      {type === 2 && (
-        <>
-          <h1 className="text-lg font-semibold">{title}</h1>
-          <div className="flex gap-2">
-            <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 공유 */}
-            <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 매물 추가 */}
-          </div>
-        </>
-      )}
-
-      {type === 3 && (
-        <>
-          <h1 className="text-lg font-semibold">{title}</h1>
-          <div className="flex gap-2">
-            <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 공유 */}
-            <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 케밥 */}
-          </div>
-        </>
-      )}
-
-      {type === 4 && (
-        <>
-          <div className="flex items-center gap-2">
-            <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 뒤로가기 */}
-            <h1 className="text-lg font-semibold">{title}</h1>
-          </div>
-          <div className="w-6" />
-        </>
-      )}
-
-      {type === 5 && (
-        <>
-          <h1 className="text-lg font-semibold">{title}</h1>
-          <div className="w-6" />
-        </>
-      )}
-
-      {type === 6 && (
-        <>
-          <div className="flex items-center gap-2">
-            <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 뒤로가기 */}
-            <h1 className="text-lg font-semibold">{title}</h1>
-          </div>
-          <div className="w-auto h-6 bg-gray-300 rounded cursor-pointer">생성</div>
-        </>
-      )}
+      {renderContent()}
     </header>
   );
 }

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,0 +1,73 @@
+interface HeaderProps {
+  type: 1 | 2 | 3 | 4 | 5 | 6;
+  title: string;
+}
+
+// type 형태
+// 1. 　　　 | 제　목 | 닫기버튼
+// 2. 제　목 |　  　　| 공유버튼, 요소추가버튼
+// 3. 제　목 |　　　　| 공유버튼, 드롭다운케밥버튼
+// 4. 백버튼 | 제　목 |
+// 5. 제　목 |       |
+// 6. 백버튼 | 제　목 | 생성버튼
+
+export default function Header({ type, title }: HeaderProps) {
+  return (
+    <header className="flex items-center justify-between px-5 py-2 bg-white shadow-[inset_1px_0_#eee,inset_-1px_0_#eee]">
+      {type === 1 && (
+        <>
+          <div className="w-6" />
+          <h1 className="text-lg font-semibold">{title}</h1>
+          <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 닫기 */}
+        </>
+      )}
+
+      {type === 2 && (
+        <>
+          <h1 className="text-lg font-semibold">{title}</h1>
+          <div className="flex gap-2">
+            <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 공유 */}
+            <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 매물 추가 */}
+          </div>
+        </>
+      )}
+
+      {type === 3 && (
+        <>
+          <h1 className="text-lg font-semibold">{title}</h1>
+          <div className="flex gap-2">
+            <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 공유 */}
+            <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 케밥 */}
+          </div>
+        </>
+      )}
+
+      {type === 4 && (
+        <>
+          <div className="flex items-center gap-2">
+            <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 뒤로가기 */}
+            <h1 className="text-lg font-semibold">{title}</h1>
+          </div>
+          <div className="w-6" />
+        </>
+      )}
+
+      {type === 5 && (
+        <>
+          <h1 className="text-lg font-semibold">{title}</h1>
+          <div className="w-6" />
+        </>
+      )}
+
+      {type === 6 && (
+        <>
+          <div className="flex items-center gap-2">
+            <div className="w-6 h-6 bg-gray-300 rounded cursor-pointer" /> {/* 뒤로가기 */}
+            <h1 className="text-lg font-semibold">{title}</h1>
+          </div>
+          <div className="w-auto h-6 bg-gray-300 rounded cursor-pointer">생성</div>
+        </>
+      )}
+    </header>
+  );
+}

--- a/src/components/Layout/TabBar.tsx
+++ b/src/components/Layout/TabBar.tsx
@@ -22,7 +22,7 @@ export default function TabBar() {
           <span className="text-xs">등록하기</span>
         </Link>
         <Link
-          href="/distance"
+          href="/map"
           className="w-1/4 flex flex-col items-center gap-1 pt-[6px] pb-3 text-gray-700 cursor-pointer"
         >
           <div className="w-7 h-7 bg-green-600" />

--- a/src/components/Layout/TabBar.tsx
+++ b/src/components/Layout/TabBar.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link';
+
+export default function TabBar() {
+  return (
+    <div
+      className="fixed bottom-0 left-1/2 px-5 w-full max-w-[428px] -translate-x-1/2 bg-white border-t border-gray-200
+"
+    >
+      <div className="flex">
+        <Link
+          href="/"
+          className="w-1/4 flex flex-col items-center gap-1 pt-[6px] pb-3 text-gray-700 cursor-pointer"
+        >
+          <div className="w-7 h-7 bg-green-600" />
+          <span className="text-xs">홈</span>
+        </Link>
+        <Link
+          href="/register"
+          className="w-1/4 flex flex-col items-center gap-1 pt-[6px] pb-3 text-gray-700 cursor-pointer"
+        >
+          <div className="w-7 h-7 bg-green-600" />
+          <span className="text-xs">등록하기</span>
+        </Link>
+        <Link
+          href="/distance"
+          className="w-1/4 flex flex-col items-center gap-1 pt-[6px] pb-3 text-gray-700 cursor-pointer"
+        >
+          <div className="w-7 h-7 bg-green-600" />
+          <span className="text-xs">거리 확인</span>
+        </Link>
+        <Link
+          href="/profile"
+          className="w-1/4 flex flex-col items-center gap-1 pt-[6px] pb-3 text-gray-700 cursor-pointer"
+        >
+          <div className="w-7 h-7 bg-green-600" />
+          <span className="text-xs">내 정보</span>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from 'react';
+import TabBar from './TabBar';
+import Header from './Header';
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+// TODO: 로그인 페이지 및 지도 페이지에서 TabBar 숨기기
+export default function Layout({ children }: LayoutProps) {
+  return (
+    <div className="flex justify-center w-full min-h-screen bg-white">
+      <div className="relative w-full max-w-[430px] min-h-screen bg-white shadow-[inset_1px_0_#eee,inset_-1px_0_#eee]">
+        <Header type={2} title="내 집 후보" /> {/* 헤더 확인용. 헤더는 각 페이지에서 사용 */}
+        {children}
+        <TabBar />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import Layout from '@/components/Layout';
 import '@/styles/globals.css';
 import '@/styles/reset.css';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -14,7 +15,9 @@ export default function App({ Component, pageProps }: AppProps) {
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
       </Head>
       <QueryClientProvider client={queryClient}>
-        <Component {...pageProps} />
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>
     </>


### PR DESCRIPTION
### 🔎 작업 내용

- [x] 레이아웃
- [x] TabBar(하단 GNB)
- [x] Header

### 📸 스크린샷
![image](https://github.com/user-attachments/assets/a1ec3b9b-7081-4094-bc32-32a9a2590fa1)


### :loudspeaker: 전달사항
헤더 타입이 다양해서 레이아웃 내부에 선언해두고 쓰지 않고, 각 페이지에서 해당하는 타입 선택해서 사용해야 합니다!
컴포넌트 사용 시 타입과 제목을 props로 전달하면 됩니다.
헤더 컴포넌트 상단에 주석으로 타입 설명 적어두었습니다.

`<Header type={2} title="내 집 후보" />`
1. 가운데 제목, 오른쪽 닫기버튼
2. 왼쪽 제목, 오른쪽 공유버튼, 요소추가버튼
3. 왼쪽 제목, 오른쪽 공유버튼, 드롭다운케밥버튼
4. 왼쪽 백버튼, 가운데 제목
5. 왼쪽 제목
6. 왼쪽 백버튼, 가운데 제목, 오른쪽 생성버튼
