### PR TITLE
Feat: Modal 컴포넌트

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,0 +1,53 @@
+import { useModalStore } from '@/store/modalStore';
+import Input from '../Input';
+import IconComponent from '../Asset/Icon';
+import CustomButton from '../Button/CustomButton';
+
+export default function Modal() {
+  const { isOpen, type, title, description, onConfirm, onCancel, closeModal } = useModalStore();
+
+  if (!isOpen || !type) return null;
+
+  return (
+    <div
+      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+      onClick={closeModal}
+    >
+      <div
+        className="relative bg-white py-6 px-5 rounded-lg w-80"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {title && <h2 className="text-b-16 text-gray-800 mb-[6px]">{title}</h2>}
+        {description && <p className="text-r-14 text-gray-800">{description}</p>}
+
+        {type === 'input' && (
+          <div className="flex flex-col gap-7 mt-[22px]">
+            <Input placeholder="값을 입력하세요" />
+            <button onClick={closeModal} className="absolute right-5 top-6">
+              <IconComponent name="close" width={14} height={14} isBtn />
+            </button>
+            <CustomButton label="저장" fullWidth onClick={onConfirm} />
+          </div>
+        )}
+
+        {type === 'confirm' && (
+          <div className="flex flex-col mt-6">
+            <CustomButton label="네" fullWidth onClick={onConfirm} />
+            <button
+              className="pt-3 flex items-center justify-center text-s-15"
+              onClick={onCancel || closeModal}
+            >
+              아니오
+            </button>
+          </div>
+        )}
+
+        {type === 'info' && (
+          <button onClick={closeModal} className="absolute right-5 top-6">
+            <IconComponent name="close" width={14} height={14} isBtn />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/constants/asset.tsx
+++ b/src/constants/asset.tsx
@@ -7,4 +7,5 @@ export const ICONS = {
   addListCheck: '/icons/add-list-check.svg',
   addListRadio: '/icons/add-list-radio.svg',
   addListText: '/icons/add-list-text.svg',
+  close: '/icons/close.svg',
 };

--- a/src/hooks/usePreventScroll.ts
+++ b/src/hooks/usePreventScroll.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+
+export const usePreventScroll = (isOpen: boolean) => {
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import Layout from '@/components/Layout';
+import Modal from '@/components/Modal';
 import Toast from '@/components/Toast';
 import '@/styles/globals.css';
 import '@/styles/reset.css';
@@ -19,6 +20,7 @@ export default function App({ Component, pageProps }: AppProps) {
         <Layout>
           <Component {...pageProps} />
           <Toast />
+          <Modal />
         </Layout>
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>

--- a/src/pages/dev-preview/index.tsx
+++ b/src/pages/dev-preview/index.tsx
@@ -4,6 +4,7 @@ import OptionButton from '@/components/Button/OptionButton';
 import ChecklistItem from '@/components/CheckList/CheckListItem';
 import Dropdown from '@/components/Dropdown';
 import Input from '@/components/Input';
+import { useModalStore } from '@/store/modalStore';
 import { useToastStore } from '@/store/toastStore';
 import React, { useState } from 'react';
 
@@ -15,6 +16,7 @@ export default function Index() {
   const [selectedOption, setSelectedOption] = useState<string>('최신 순');
   const options = ['최신 순', '입주 빠른 순'];
   const { showToast } = useToastStore();
+  const { openModal } = useModalStore();
 
   return (
     <div className="pb-[66px]">
@@ -102,6 +104,41 @@ export default function Index() {
           className="ml-4 px-4 py-2 bg-red-500 text-white rounded-lg"
         >
           에러 토스트
+        </button>
+      </div>
+      <div className="p-6">
+        <button
+          onClick={() =>
+            openModal('info', {
+              title: '알림',
+              description:
+                '정보 모달 정보 모달 정보 모달 정보 모달 정보 모달 정보 모달 정보 모달 정보 모달 ',
+            })
+          }
+          className="mr-2"
+        >
+          정보 모달
+        </button>
+
+        <button
+          onClick={() =>
+            openModal('input', { title: '새 템플릿 생성', onConfirm: () => alert('생성됨') })
+          }
+          className="mr-2"
+        >
+          입력 모달
+        </button>
+
+        <button
+          onClick={() =>
+            openModal('confirm', {
+              title: '확인',
+              description: '나의 체크리스트에 저장하시겠어요?',
+              onConfirm: () => alert('저장됨'),
+            })
+          }
+        >
+          확인 모달
         </button>
       </div>
     </div>

--- a/src/store/modalStore.ts
+++ b/src/store/modalStore.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand';
+
+type ModalType = 'info' | 'input' | 'confirm';
+
+interface ModalState {
+  isOpen: boolean;
+  type: ModalType | null;
+  title?: string;
+  description?: string;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+
+  openModal: (
+    type: ModalType,
+    options?: Partial<Omit<ModalState, 'isOpen' | 'openModal' | 'closeModal'>>,
+  ) => void;
+  closeModal: () => void;
+}
+
+export const useModalStore = create<ModalState>((set) => ({
+  isOpen: false,
+  type: null,
+  title: '',
+  description: '',
+  onConfirm: undefined,
+  onCancel: undefined,
+
+  openModal: (type, options = {}) => set({ isOpen: true, type, ...options }),
+
+  closeModal: () => set({ isOpen: false, type: null, title: '', description: '' }),
+}));


### PR DESCRIPTION
### 🔎 작업 내용

- [x] Modal 컴포넌트

### 📸 스크린샷
![image](https://github.com/user-attachments/assets/96398998-37d4-4a12-b426-dc039d4084ef)
![image](https://github.com/user-attachments/assets/d39ce1fe-ac62-4de2-b583-8d09bec7ee1a)
![image](https://github.com/user-attachments/assets/e5b0b639-8c8f-48f0-bc9d-ee9681787634)

### :loudspeaker: 전달사항
- 타입은 info(용어 알려주는 모달), input(값 입력받는 모달), confirm(확인 모달) 세 가지입니다.
- `const { openModal } = useModalStore();` 선언 후 아래처럼 타입, 내용 입력하시면 됩니다.
- `openModal('info', {title: '알림', description: '정보 모달'})`
- `openModal('input', { title: '새 템플릿 생성', onConfirm: () => alert('생성됨') })`
- `openModal('confirm', {title: '확인', description: '나의 체크리스트에 저장하시겠어요?', onConfirm: () => alert('저장됨')})`
