### PR TITLE
Feat: 매물 생성 하단 고정 버튼

### DIFF
--- a/src/components/FixedBar/index.tsx
+++ b/src/components/FixedBar/index.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+import Button from '../Button/CustomButton';
+
+export default function FixedBar() {
+  return (
+    <div className="flex flex-col items-center w-full bg-primary fixed bottom-0 left-1/2 max-w-[428px] -translate-x-1/2 z-10">
+      <div className="absolute -top-10 left-0 w-full h-10 bg-gradient-to-b from-transparent to-primary" />
+      <div className="w-full p-5 flex flex-col items-center gap-2">
+        <Button label="완료" className="w-full" />
+        <Link href="/" className="py-3 text-[15px] text-gray-800 font-semibold">
+          건너 뛰기
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/FixedBar/index.tsx
+++ b/src/components/FixedBar/index.tsx
@@ -1,13 +1,18 @@
 import Link from 'next/link';
 import Button from '../Button/CustomButton';
 
-export default function FixedBar() {
+interface Props {
+  disabled: boolean;
+  skipRoute: string;
+}
+
+export default function FixedBar({ disabled, skipRoute }: Props) {
   return (
     <div className="flex flex-col items-center w-full bg-primary fixed bottom-0 left-1/2 max-w-[428px] -translate-x-1/2 z-10">
       <div className="absolute -top-10 left-0 w-full h-10 bg-gradient-to-b from-transparent to-primary" />
       <div className="w-full p-5 flex flex-col items-center gap-2">
-        <Button label="완료" className="w-full" />
-        <Link href="/" className="py-3 text-[15px] text-gray-800 font-semibold">
+        <Button disabled={disabled} label="완료" className="w-full" />
+        <Link href={skipRoute} className="py-3 text-[15px] text-gray-800 font-semibold">
           건너 뛰기
         </Link>
       </div>

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -8,7 +8,7 @@ interface LayoutProps {
 }
 
 // 숨길 페이지 목록
-const HIDDEN_TABBAR_PAGES = ['/login', '/map', '/add-photo', '/checklist', '/details'];
+const HIDDEN_TABBAR_PAGES = ['/login', '/map', '/add-photo', '/checklist', '/details', '/create'];
 const HIDDEN_HEADER_PAGES = ['/login', '/add-photo', '/checklist', '/details'];
 
 export default function Layout({ children }: LayoutProps) {

--- a/src/components/map/SearchAddress.tsx
+++ b/src/components/map/SearchAddress.tsx
@@ -5,9 +5,9 @@ import DaumPostcodeEmbed, { Address } from 'react-daum-postcode';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../ui/form';
 import { Input } from '../ui/input';
-import { Button } from '../ui/button';
 import Image from 'next/image';
 import { createRoomZodSchema } from '@/lib/zodSchema';
+import FixedBar from '../FixedBar';
 
 declare global {
   interface Window {
@@ -149,9 +149,7 @@ export default function SearchAddress() {
               </p>
             </div>
           </div>
-          <Button type="submit" className="w-full" disabled={!form.formState.isValid && !isPending}>
-            다음
-          </Button>
+          <FixedBar disabled={!form.formState.isValid && !isPending} skipRoute="/create/2" />
         </form>
       </Form>
       {isSearchModalOpen && (

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,6 +18,7 @@ const config: Config = {
       colors: {
         background: 'hsl(var(--background))',
         foreground: 'hsl(var(--foreground))',
+        primary: '#F6F5F2',
         violet: {
           '100': '#EDE7F6',
           '200': '#D1C4E9',
@@ -61,10 +62,6 @@ const config: Config = {
         popover: {
           DEFAULT: 'hsl(var(--popover))',
           foreground: 'hsl(var(--popover-foreground))',
-        },
-        primary: {
-          DEFAULT: 'hsl(var(--primary))',
-          foreground: 'hsl(var(--primary-foreground))',
         },
         secondary: {
           DEFAULT: 'hsl(var(--secondary))',


### PR DESCRIPTION
### 🔎 작업 내용

- [x] 하단 고정 바 생성
- [x] 매물 생성 form 연결

### 📸 스크린샷

![스크린샷 2025-03-13 오전 11 07 43](https://github.com/user-attachments/assets/25f7b434-139d-4b63-a37a-d2e09882470e)

- 기존 매물 생성 form 버튼 자리에 넣어주시면 됩니다. `disabled` 옵션과 건너뛰기할 route를 넣어서 사용하시면 됩니다.
- 추가적으로 primary 색상 추가했습니다.

### :loudspeaker: 전달사항

- 없음
