### PR TITLE
Feat - institution page

### DIFF
--- a/src/components/Institution/index.tsx
+++ b/src/components/Institution/index.tsx
@@ -1,0 +1,148 @@
+import { AddressSearchStatus } from '@/utils/getCoordinates';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useCallback, useEffect, useState, useTransition } from 'react';
+import DaumPostcodeEmbed, { Address } from 'react-daum-postcode';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../ui/form';
+import { Input } from '../ui/input';
+import Image from 'next/image';
+import { createInstitutionZodSchema } from '@/lib/zodSchema';
+import FixedBar from '../FixedBar';
+
+declare global {
+  interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    kakao: any;
+  }
+}
+
+type InstitutionSchema = {
+  address: string;
+  nickName: string;
+};
+
+export default function InstitutionForm() {
+  const [isSearchModalOpen, setIsSearchModalOpen] = useState(false);
+  const [addressCoordinate, setAddressCoordinate] = useState({ x: '', y: '' });
+  const [isPending, startTransition] = useTransition();
+
+  const form = useForm<InstitutionSchema>({
+    resolver: zodResolver(createInstitutionZodSchema),
+    defaultValues: {
+      address: '',
+      nickName: '',
+    },
+    mode: 'onBlur',
+  });
+
+  const onSubmit: SubmitHandler<InstitutionSchema> = (values) => {
+    startTransition(async () => {
+      console.log(values, addressCoordinate); // 주소 및 좌표 설정 API
+    });
+  };
+
+  const completeSearch = (data: Address) => {
+    // 주소 검색후 주소 클릭시 동작하는 함수
+    form.setValue('address', data.address);
+    form.trigger('address');
+    const geocoder = new window.kakao.maps.services.Geocoder();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    geocoder.addressSearch(data.address, (result: any, status: AddressSearchStatus) => {
+      // 카카오맵 API활용, 주소 -> 좌표 변환 로직
+      if (status === window.kakao.maps.services.Status.OK) {
+        setAddressCoordinate({ x: result[0].x, y: result[0].y });
+        form.setValue('nickName', result[0].road_address.building_name); // 건물 이름을 기본 값으로 설정
+        form.trigger('nickName');
+        setIsSearchModalOpen(false);
+      }
+    });
+  };
+
+  const initMap = useCallback(() => {
+    window.kakao.maps.load();
+  }, []);
+
+  useEffect(() => {
+    if (window.kakao && window.kakao.maps) {
+      initMap();
+    } else {
+      const mapScript = document.createElement('script');
+      mapScript.async = true;
+      mapScript.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_API_KEY}&autoload=false&libraries=services`;
+      document.head.appendChild(mapScript);
+      mapScript.addEventListener('load', initMap);
+
+      return () => {
+        mapScript.removeEventListener('load', initMap);
+        document.head.removeChild(mapScript);
+      };
+    }
+  }, [initMap]);
+
+  return (
+    <div>
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="h-full flex flex-col justify-between"
+        >
+          <div className="flex flex-col gap-14">
+            <div className="flex flex-col gap-[6px]">
+              <div className="flex gap-1.5">
+                <FormLabel className="mb-2 text-[16px] font-bold">직장/학교 주소</FormLabel>
+                <p className="text-[12px] text-gray-500 mb-2 justify-center flex flex-col">
+                  상세 주소 생략
+                </p>
+              </div>
+              <div onClick={() => setIsSearchModalOpen(true)} className="cursor-pointer relative">
+                <FormField
+                  control={form.control}
+                  name="address"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormControl>
+                        <Input
+                          disabled
+                          {...field}
+                          placeholder="주소를 검색해 주세요"
+                          className="pointer-events-none bg-white py-2 h-10 disabled:opacity-100" // 클릭 이벤트 차단 및 스타일 변경
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <Image
+                  src="/icons/SearchIcon.svg"
+                  alt="검색아이콘"
+                  height={24}
+                  width={24}
+                  className="absolute right-3 top-2"
+                />
+              </div>
+            </div>
+            <FormField
+              control={form.control}
+              name="nickName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="mb-2 text-[16px] font-bold">직장/학교명</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder="직장명/학교명" className="bg-white py-2 h-10" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <FixedBar disabled={!form.formState.isValid && !isPending} skipRoute="/" />
+        </form>
+      </Form>
+      {isSearchModalOpen && (
+        <div className="absolute inset-0">
+          <DaumPostcodeEmbed onComplete={completeSearch} style={{ height: '100%' }} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/map/CreateInstitutionButton.tsx
+++ b/src/components/map/CreateInstitutionButton.tsx
@@ -1,14 +1,12 @@
+import { useRouter } from 'next/navigation';
 import IconComponent from '../Asset/Icon';
 
-interface Props {
-  handleClick: () => void;
-}
-
-export default function CreateInstitutionButton({ handleClick }: Props) {
+export default function CreateInstitutionButton() {
+  const router = useRouter();
   return (
     <button
       type="button"
-      onClick={handleClick}
+      onClick={() => router.push('/create/institution')}
       className="flex gap-1 w-full items-center justify-center bg-white px-4 py-2 rounded-md border border-black font-semibold"
     >
       <IconComponent name="plus" alt="플러스 아이콘" width={12} height={12} />

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -14,7 +14,7 @@ declare global {
 
 interface Props {
   roomList: Property[];
-  institution: Institution;
+  institution?: Institution;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   settingMapObject: (object: any) => void;
   handleMarkerClick: (content: ModalContent) => void;
@@ -152,69 +152,75 @@ export function Map({ roomList, institution, settingMapObject, handleMarkerClick
           },
         );
       });
-      geocoder.addressSearch(
-        institution.institutionAddress,
-        (result: AddressSearchResult[], status: AddressSearchStatus) => {
-          if (status === window.kakao.maps.services.Status.OK) {
-            const coords = new window.kakao.maps.LatLng(result[0].y, result[0].x);
-            const imageSrc: string = whiteMarkerIcon.src;
-            const imageSize = new window.kakao.maps.Size(24, 24);
-            const imageOption = { offset: new window.kakao.maps.Point(12, 24) };
-            const markerImage = new window.kakao.maps.MarkerImage(imageSrc, imageSize, imageOption);
-            const formatContent = {
-              address: institution.institutionAddress,
-              name: institution.institutionName,
-            };
+      if (institution) {
+        geocoder.addressSearch(
+          institution.institutionAddress,
+          (result: AddressSearchResult[], status: AddressSearchStatus) => {
+            if (status === window.kakao.maps.services.Status.OK) {
+              const coords = new window.kakao.maps.LatLng(result[0].y, result[0].x);
+              const imageSrc: string = whiteMarkerIcon.src;
+              const imageSize = new window.kakao.maps.Size(24, 24);
+              const imageOption = { offset: new window.kakao.maps.Point(12, 24) };
+              const markerImage = new window.kakao.maps.MarkerImage(
+                imageSrc,
+                imageSize,
+                imageOption,
+              );
+              const formatContent = {
+                address: institution.institutionAddress,
+                name: institution.institutionName,
+              };
 
-            const marker = new window.kakao.maps.Marker({
-              position: coords,
-              map: newMap,
-              title: institution.institutionName,
-              image: markerImage,
-            });
+              const marker = new window.kakao.maps.Marker({
+                position: coords,
+                map: newMap,
+                title: institution.institutionName,
+                image: markerImage,
+              });
 
-            window.kakao.maps.event.addListener(marker, 'click', () => {
-              handleMarkerClick(formatContent);
-            });
+              window.kakao.maps.event.addListener(marker, 'click', () => {
+                handleMarkerClick(formatContent);
+              });
 
-            const customOverlayContent = document.createElement('div');
-            customOverlayContent.innerHTML = `
-            <div style="
-                cursor: pointer;
-                display: flex; 
-                justify-content: center; 
-                align-items: center; 
-                padding: 6px 12px; 
-                font-size: 14px; 
-                color: #000; 
-                text-align: center; 
-                font-weight: 600; 
-                background-color: white; 
-                border-radius: 9999px; 
-                white-space: nowrap;
-                position: relative;
-                top: -3px;
-                min-width: 50px;
-              ">
-                ${institution.institutionName}
-              </div>
-            `;
+              const customOverlayContent = document.createElement('div');
+              customOverlayContent.innerHTML = `
+              <div style="
+                  cursor: pointer;
+                  display: flex; 
+                  justify-content: center; 
+                  align-items: center; 
+                  padding: 6px 12px; 
+                  font-size: 14px; 
+                  color: #000; 
+                  text-align: center; 
+                  font-weight: 600; 
+                  background-color: white; 
+                  border-radius: 9999px; 
+                  white-space: nowrap;
+                  position: relative;
+                  top: -3px;
+                  min-width: 50px;
+                ">
+                  ${institution.institutionName}
+                </div>
+              `;
 
-            customOverlayContent.addEventListener('click', () => {
-              handleMarkerClick(formatContent);
-            });
+              customOverlayContent.addEventListener('click', () => {
+                handleMarkerClick(formatContent);
+              });
 
-            const customOverlay = new window.kakao.maps.CustomOverlay({
-              map: newMap,
-              position: coords,
-              content: customOverlayContent,
-              yAnchor: 1.2, // 마커 위쪽에 오도록 조정
-            });
+              const customOverlay = new window.kakao.maps.CustomOverlay({
+                map: newMap,
+                position: coords,
+                content: customOverlayContent,
+                yAnchor: 1.2, // 마커 위쪽에 오도록 조정
+              });
 
-            customOverlay.setMap(newMap);
-          }
-        },
-      );
+              customOverlay.setMap(newMap);
+            }
+          },
+        );
+      }
     });
   }, [map]);
 

--- a/src/components/map/RoomContainer.tsx
+++ b/src/components/map/RoomContainer.tsx
@@ -1,5 +1,6 @@
 import { Institution, Property } from '@/types';
 import IconComponent from '../Asset/Icon';
+import { useRouter } from 'next/navigation';
 
 interface Props {
   roomList: Property[];
@@ -8,6 +9,8 @@ interface Props {
 }
 
 export function RoomContainer({ roomList, institution, handleTagClick }: Props) {
+  const router = useRouter();
+
   return (
     <ul className="flex gap-2.5 flex-col w-full">
       <div
@@ -18,7 +21,14 @@ export function RoomContainer({ roomList, institution, handleTagClick }: Props) 
           <p className="font-bold">{institution.institutionName}</p>
           <p>{institution.institutionAddress}</p>
         </div>
-        <IconComponent name="pencil" width={16} height={16} alt="수정 아이콘" />
+        <IconComponent
+          name="pencil"
+          width={16}
+          height={16}
+          alt="수정 아이콘"
+          onClick={() => router.push('/create/institution')}
+          className="cursor-pointer"
+        />
       </div>
       {roomList.map((item) => (
         <li key={item.id} className="flex gap-[6px] items-center">

--- a/src/components/map/RoomContainer.tsx
+++ b/src/components/map/RoomContainer.tsx
@@ -1,10 +1,11 @@
 import { Institution, Property } from '@/types';
 import IconComponent from '../Asset/Icon';
 import { useRouter } from 'next/navigation';
+import CreateInstitutionButton from './CreateInstitutionButton';
 
 interface Props {
   roomList: Property[];
-  institution: Institution;
+  institution?: Institution;
   handleTagClick: (address: string, name: string) => Promise<void>;
 }
 
@@ -13,23 +14,29 @@ export function RoomContainer({ roomList, institution, handleTagClick }: Props) 
 
   return (
     <ul className="flex gap-2.5 flex-col w-full">
-      <div
-        onClick={() => handleTagClick(institution.institutionAddress, institution.institutionName)}
-        className={`px-2.5 py-1.5 w-full rounded-sm cursor-pointer text-[14px] bg-white leading-tight flex justify-between mb-2.5`}
-      >
-        <div className="flex gap-1.5">
-          <p className="font-bold">{institution.institutionName}</p>
-          <p>{institution.institutionAddress}</p>
+      {institution ? (
+        <div
+          onClick={() =>
+            handleTagClick(institution.institutionAddress, institution.institutionName)
+          }
+          className={`px-2.5 py-1.5 w-full rounded-sm cursor-pointer text-[14px] bg-white leading-tight flex justify-between mb-2.5`}
+        >
+          <div className="flex gap-1.5">
+            <p className="font-bold">{institution.institutionName}</p>
+            <p>{institution.institutionAddress}</p>
+          </div>
+          <IconComponent
+            name="pencil"
+            width={16}
+            height={16}
+            alt="수정 아이콘"
+            onClick={() => router.push('/create/institution')}
+            className="cursor-pointer"
+          />
         </div>
-        <IconComponent
-          name="pencil"
-          width={16}
-          height={16}
-          alt="수정 아이콘"
-          onClick={() => router.push('/create/institution')}
-          className="cursor-pointer"
-        />
-      </div>
+      ) : (
+        <CreateInstitutionButton />
+      )}
       {roomList.map((item) => (
         <li key={item.id} className="flex gap-[6px] items-center">
           <div

--- a/src/components/map/infoModal.tsx
+++ b/src/components/map/infoModal.tsx
@@ -8,16 +8,17 @@ import { getCoordinates } from '@/utils/getCoordinates';
 
 interface Props {
   modalContent: ModalContent;
-  institution: Institution;
+  institution?: Institution;
   closeModal: () => void;
 }
 
 export default function InfoModal({ modalContent, closeModal, institution }: Props) {
   const [distance, setDistance] = useState(0);
   const [isDetail, setIsDetail] = useState(false);
-  const isInstitution = modalContent.address === institution.institutionAddress;
+  const isInstitution = institution && modalContent.address === institution.institutionAddress;
 
   useEffect(() => {
+    if (!institution) return;
     const calculater = async () => {
       const spotCoorder = await getCoordinates(modalContent.address);
       const result = calculateDistance(
@@ -46,12 +47,12 @@ export default function InfoModal({ modalContent, closeModal, institution }: Pro
           />
           <p className="text-md font-bold">{modalContent?.name}</p>
           <p className="text-[15px]">{modalContent?.address}</p>
-          {!isInstitution && (
+          {!isInstitution && institution && (
             <p className="text-[15px] text-[#94896A] font-bold">
               {institution.institutionName}에서 {distance}m
             </p>
           )}
-          {!isInstitution && (
+          {!isInstitution && institution && (
             <div
               className="w-fit flex items-center gap-[2px] rounded-full border px-4 py-2.5 font-semibold cursor-pointer mt-2.5"
               onClick={() => setIsDetail(true)}
@@ -78,7 +79,7 @@ export default function InfoModal({ modalContent, closeModal, institution }: Pro
           />
         </div>
       </div>
-      {isDetail && !isInstitution && (
+      {isDetail && !isInstitution && institution && (
         <DetailRouteModal
           institution={institution}
           currentAddress={modalContent}

--- a/src/lib/zodSchema.ts
+++ b/src/lib/zodSchema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const createRoomZodSchema = z.object({
-  address: z.string().trim().min(1, { message: '주소는 필수 입니다.' }),
+  address: z.string().trim().min(1, { message: '주소는 필수입니다.' }),
   addressDetail: z
     .string()
     .trim()
@@ -16,4 +16,9 @@ export const roomInfoZodSchema = z.object({
   monthlyRent: z.number(),
   maintenanceFee: z.number().optional(),
   available: z.string().trim(),
+});
+
+export const createInstitutionZodSchema = z.object({
+  address: z.string().trim().min(1, { message: '주소는 필수입니다.' }),
+  nickName: z.string().trim().max(20, { message: '장소 이름은 최대 20글자까지만 가능합니다.' }),
 });

--- a/src/pages/create/institution/index.tsx
+++ b/src/pages/create/institution/index.tsx
@@ -1,0 +1,21 @@
+import InstitutionForm from '@/components/Institution';
+import Header from '@/components/Layout/Header';
+
+export default function Page() {
+  return (
+    <div>
+      <Header type={1} title="직장/학교 등록" />
+      <div className="px-5 py-8 flex flex-col gap-14 relative h-[calc(100vh-40px)]">
+        <div className="flex items-center gap-3 px-5 py-4 bg-white rounded-lg">
+          <div className="w-12 h-12 bg-gray-300 rounded-lg" />
+          <p className="text-sm leading-tight">
+            주소를 등록하면,
+            <br />
+            매물 후보와 거리를 알려줄게요
+          </p>
+        </div>
+        <InstitutionForm />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -5,7 +5,6 @@ import Header from '@/components/Layout/Header';
 import { mockHouserData, mockInstitutionData } from '@/data/mockHouseData';
 import { RoomContainer } from '@/components/map/RoomContainer';
 import { Map } from '@/components/map/Map';
-import CreateInstitutionButton from '@/components/map/CreateInstitutionButton';
 
 export interface ModalContent {
   address: string;
@@ -50,15 +49,11 @@ export default function Page() {
       <div className="flex flex-col absolute top-0 right-0 left-0 z-10 bg-primary">
         <Header type={5} title="지도" />
         <div className="p-5">
-          {mockInstitutionData ? (
-            <RoomContainer
-              roomList={mockHouserData}
-              handleTagClick={handleTagClick}
-              institution={mockInstitutionData}
-            />
-          ) : (
-            <CreateInstitutionButton />
-          )}
+          <RoomContainer
+            roomList={mockHouserData}
+            handleTagClick={handleTagClick}
+            institution={mockInstitutionData}
+          />
         </div>
       </div>
       <Map

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -6,7 +6,6 @@ import { mockHouserData, mockInstitutionData } from '@/data/mockHouseData';
 import { RoomContainer } from '@/components/map/RoomContainer';
 import { Map } from '@/components/map/Map';
 import CreateInstitutionButton from '@/components/map/CreateInstitutionButton';
-import CreateInsitutionModal from '@/components/map/CreateInstitutionModal';
 
 export interface ModalContent {
   address: string;
@@ -18,11 +17,6 @@ export default function Page() {
   const [modalContent, setModalContent] = useState<ModalContent | null>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [map, setMap] = useState<any>(null);
-  const [isInstitutionModal, setIsInstitutionModal] = useState(false);
-
-  const toggleModal = () => {
-    setIsInstitutionModal(!isInstitutionModal);
-  };
 
   const closeModal = () => {
     setIsModalOpen(false);
@@ -63,7 +57,7 @@ export default function Page() {
               institution={mockInstitutionData}
             />
           ) : (
-            <CreateInstitutionButton handleClick={toggleModal} />
+            <CreateInstitutionButton />
           )}
         </div>
       </div>
@@ -80,7 +74,6 @@ export default function Page() {
           closeModal={closeModal}
         />
       )}
-      {isInstitutionModal && <CreateInsitutionModal handleClick={toggleModal} />}
     </div>
   );
 }


### PR DESCRIPTION
### 🔎 작업 내용

- [x] institution, 위치 등록하는 페이지가 없어서 만들었습니다.
- [x] 최초 로그인시 리디렉션은 추후에 연결해도 될것같고, 우선 지도 페이지에서 위치 등록하는 경우에도 `/create/instituion`페이지로 이동시켜줬습니다. 수정인지 생성인지 여부는 나중에 세세하게 작업해도 될듯합니다.

### 📸 스크린샷

<img width="500" alt="스크린샷 2025-03-27 오후 5 37 02" src="https://github.com/user-attachments/assets/4aff90e7-1832-4180-9f89-1516ba00d899" />

### :loudspeaker: 전달사항

- 건너뛰기 클릭시 `/` 메인 페이지로 이동하고, 다음 버튼 클릭시 form이 제출되도록 했기 때문에 submit 이벤트에 route 넣어주면 됩니다.
