### PR TITLE
Feat/share room page

### DIFF
--- a/public/icons/marker-brown.svg
+++ b/public/icons/marker-brown.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="8" viewBox="0 0 10 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5 8L0.669872 0.500001L9.33013 0.5L5 8Z" fill="#94896A"/>
+</svg>

--- a/src/components/DashBoard/HouseCard.tsx
+++ b/src/components/DashBoard/HouseCard.tsx
@@ -7,15 +7,16 @@ import { formatWon } from '@/utils/formatWon';
 
 interface Props {
   info: Property;
-  onDelete: (id: number) => void;
-  onAdd: (id: number) => void;
-  isFixed: boolean;
+  onDelete?: (id: number) => void;
+  onAdd?: (id: number) => void;
+  isFixed?: boolean;
+  isShared?: boolean;
 }
 
 const defaultMenuList = ['고정하기', '수정하기', '삭제하기'];
 const cancelOptionMenuList = ['고정 해제하기', '수정하기', '삭제하기'];
 
-export default function HouseCard({ info, onDelete, onAdd, isFixed }: Props) {
+export default function HouseCard({ info, onDelete, onAdd, isFixed, isShared }: Props) {
   const handleSelect = (option: string) => {
     switch (option) {
       case '고정 해제하기':
@@ -43,14 +44,16 @@ export default function HouseCard({ info, onDelete, onAdd, isFixed }: Props) {
     <div className="w-full flex flex-col gap-2">
       <div className="flex justify-between items-center">
         <h1 className="font-bold text-lg">{info.propertyName}</h1>
-        <div className="flex gap-5">
-          {isFixed && <IconComponent name="pin" width={20} height={20} />}
-          <Dropdown
-            options={isFixed ? cancelOptionMenuList : defaultMenuList}
-            type="meatball"
-            onSelect={handleSelect}
-          />
-        </div>
+        {!isShared && (
+          <div className="flex gap-5">
+            {isFixed && <IconComponent name="pin" width={20} height={20} />}
+            <Dropdown
+              options={isFixed ? cancelOptionMenuList : defaultMenuList}
+              type="meatball"
+              onSelect={handleSelect}
+            />
+          </div>
+        )}
       </div>
       <Link href={`/details/${info.id}`}>
         <div className="flex w-full justify-between items-center rounded-lg bg-white border p-5">

--- a/src/components/DashBoard/ShareCard.tsx
+++ b/src/components/DashBoard/ShareCard.tsx
@@ -1,0 +1,40 @@
+import HouseTypeTag from './HouseTypeTag';
+import { Property } from '@/types';
+import { formatWon } from '@/utils/formatWon';
+
+interface Props {
+  info: Property;
+  checked: boolean;
+  onChange: (id: Property) => void;
+}
+
+export default function ShareCard({ info, checked, onChange }: Props) {
+  return (
+    <div className="w-full flex flex-col gap-2">
+      <div className="flex gap-1  items-center">
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={() => onChange(info)}
+          id={info.propertyAddress}
+          className="accent-gray-800"
+        />
+        <label htmlFor={info.propertyAddress} className="font-bold text-lg/7">
+          {info.propertyName}
+        </label>
+      </div>
+      <div className="flex w-full justify-between items-center rounded-lg bg-white border p-5">
+        <div className="flex flex-col gap-1">
+          <HouseTypeTag type={info.leaseType} />
+          <div className="flex font-bold text-base gap-1">
+            <p>보증금 {formatWon(info.deposit)}</p>
+            {info.leaseType !== 'JEONSE' && <p>/</p>}
+            {info.monthlyFee && <p>월세 {formatWon(info.monthlyFee)}</p>}
+          </div>
+          <p className="text-gray-500 text-sm">{info.propertyAddress}</p>
+        </div>
+        <div className="bg-gray-200 w-16 h-16 rounded"></div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -62,7 +62,7 @@ export default function Dropdown({ options, selectedOption, onSelect, type }: Dr
                   }
                   setIsOpen(false);
                 }}
-                className="w-full p-2 rounded-[4px] text-r-14 text-left text-gray-700 hover:bg-gray-100"
+                className="w-full p-2 rounded-[4px] text-r-14 text-left text-gray-800 hover:bg-secondary"
               >
                 {option}
               </button>

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/navigation';
 import IconComponent from '../Asset/Icon';
+import Dropdown from '../Dropdown';
 
 interface HeaderProps {
   type: 1 | 2 | 3 | 4 | 5 | 6;
@@ -15,8 +16,28 @@ interface HeaderProps {
 // 5. 제　목 |       |
 // 6. 백버튼 | 제　목 | 생성버튼
 
+const ROOM_DETAIL_OPTION = ['매물 정보 수정', '사진 수정', '삭제'];
+
 export default function Header({ type, title, addAction }: HeaderProps) {
   const router = useRouter();
+  const roomDeatilhandleSelect = (option: string) => {
+    switch (option) {
+      case '매물 정보 수정':
+        console.log('매물 정보 수정 기능 실행');
+
+        break;
+      case '사진 수정':
+        console.log('사진 수정 기능 실행');
+
+        break;
+      case '삭제':
+        console.log('삭제 기능 실행');
+        break;
+      default:
+        console.log('알 수 없는 옵션');
+    }
+  };
+
   const renderContent = () => {
     switch (type) {
       case 1:
@@ -46,17 +67,24 @@ export default function Header({ type, title, addAction }: HeaderProps) {
       case 3:
         return (
           <>
-            <IconComponent
-              name="arrowLeft"
-              width={24}
-              height={24}
-              onClick={() => router.back()}
-              className="cursor-pointer"
-            />
-            <h1 className="text-b-20">{title}</h1>
-            <div className="flex gap-5">
+            <div className="flex gap-2 items-center">
+              <IconComponent
+                name="arrowLeft"
+                width={24}
+                height={24}
+                onClick={() => router.back()}
+                className="cursor-pointer"
+              />
+              <h1 className="text-b-20 text-start">{title}</h1>
+            </div>
+            <div className="flex gap-3">
+              <IconComponent name="pin" width={24} height={24} className="cursor-pointer" />
               <IconComponent name="share" width={16} height={16} className="cursor-pointer" />
-              <IconComponent name="meatball" width={27} height={27} className="cursor-pointer" />
+              <Dropdown
+                options={ROOM_DETAIL_OPTION}
+                type="meatball"
+                onSelect={roomDeatilhandleSelect}
+              />
             </div>
           </>
         );

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -3,7 +3,7 @@ import IconComponent from '../Asset/Icon';
 import Dropdown from '../Dropdown';
 
 interface HeaderProps {
-  type: 1 | 2 | 3 | 4 | 5 | 6;
+  type: 1 | 2 | 3 | 4 | 5 | 6 | 7;
   title: string;
   addAction?: () => void;
 }
@@ -15,6 +15,7 @@ interface HeaderProps {
 // 4. 백버튼 | 제　목 |
 // 5. 제　목 |       |
 // 6. 백버튼 | 제　목 | 생성버튼
+// 7. 　　　 | 제　목 |
 
 const ROOM_DETAIL_OPTION = ['매물 정보 수정', '사진 수정', '삭제'];
 
@@ -45,7 +46,13 @@ export default function Header({ type, title, addAction }: HeaderProps) {
           <>
             <div className="w-6" />
             <h1 className="text-b-20">{title}</h1>
-            <IconComponent name="close" width={16} height={16} className="cursor-pointer" />
+            <IconComponent
+              name="close"
+              width={16}
+              height={16}
+              className="cursor-pointer"
+              onClick={() => router.back()}
+            />
           </>
         );
       case 2:
@@ -53,7 +60,13 @@ export default function Header({ type, title, addAction }: HeaderProps) {
           <>
             <h1 className="text-b-20">{title}</h1>
             <div className="flex gap-5">
-              <IconComponent name="share" width={16} height={16} className="cursor-pointer" />
+              <IconComponent
+                name="share"
+                width={16}
+                height={16}
+                className="cursor-pointer"
+                onClick={() => router.push('/share')}
+              />
               <IconComponent
                 name="plus"
                 width={18}
@@ -131,6 +144,14 @@ export default function Header({ type, title, addAction }: HeaderProps) {
               onClick={addAction}
               className="cursor-pointer"
             />
+          </>
+        );
+      case 7:
+        return (
+          <>
+            <div className="w-6" />
+            <h1 className="text-b-20">{title}</h1>
+            <div className="w-6" />
           </>
         );
       default:

--- a/src/components/Layout/KakaoScript.tsx
+++ b/src/components/Layout/KakaoScript.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import Script from 'next/script';
+
+export default function KakaoScript() {
+  const onLoad = () => {
+    window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_API_KEY);
+  };
+
+  return <Script src="https://developers.kakao.com/sdk/js/kakao.js" async onLoad={onLoad} />;
+}

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -8,8 +8,8 @@ interface LayoutProps {
 }
 
 // 숨길 페이지 목록
-const HIDDEN_TABBAR_PAGES = ['/login', '/details', '/create'];
-const HIDDEN_HEADER_PAGES = ['/login', '/details', '/create', '/map'];
+const HIDDEN_TABBAR_PAGES = ['/login', '/details', '/create', '/share', '/view'];
+const HIDDEN_HEADER_PAGES = ['/login', '/details', '/create', '/map', '/share', '/view'];
 const HIDEEN_LAYOUT_ROUTE = '/create';
 const MYPAGE_ROUTE = '/profile';
 const DETAIL_ROUTE = '/details';

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -2,7 +2,7 @@ import { Institution, Property } from '@/types';
 import { AddressSearchResult, AddressSearchStatus } from '@/utils/getCoordinates';
 import { useCallback, useEffect, useState } from 'react';
 import markerIcon from '../../../public/icons/marker.svg';
-import whiteMarkerIcon from '../../../public/icons/marker-white.svg';
+import borwnMarkerIcon from '../../../public/icons/marker-brown.svg';
 import { ModalContent } from '@/pages/map';
 
 declare global {
@@ -158,7 +158,7 @@ export function Map({ roomList, institution, settingMapObject, handleMarkerClick
           (result: AddressSearchResult[], status: AddressSearchStatus) => {
             if (status === window.kakao.maps.services.Status.OK) {
               const coords = new window.kakao.maps.LatLng(result[0].y, result[0].x);
-              const imageSrc: string = whiteMarkerIcon.src;
+              const imageSrc: string = borwnMarkerIcon.src;
               const imageSize = new window.kakao.maps.Size(24, 24);
               const imageOption = { offset: new window.kakao.maps.Point(12, 24) };
               const markerImage = new window.kakao.maps.MarkerImage(
@@ -191,10 +191,10 @@ export function Map({ roomList, institution, settingMapObject, handleMarkerClick
                   align-items: center; 
                   padding: 6px 12px; 
                   font-size: 14px; 
-                  color: #000; 
+                  color: #ffffff; 
                   text-align: center; 
                   font-weight: 600; 
-                  background-color: white; 
+                  background-color: #94896A; 
                   border-radius: 9999px; 
                   white-space: nowrap;
                   position: relative;

--- a/src/components/map/RoomContainer.tsx
+++ b/src/components/map/RoomContainer.tsx
@@ -21,9 +21,9 @@ export function RoomContainer({ roomList, institution, handleTagClick }: Props) 
           }
           className={`px-2.5 py-1.5 w-full rounded-sm cursor-pointer text-[14px] bg-white leading-tight flex justify-between mb-2.5`}
         >
-          <div className="flex gap-1.5">
-            <p className="font-bold">{institution.institutionName}</p>
-            <p>{institution.institutionAddress}</p>
+          <div className="flex gap-1.5 ">
+            <p className="font-bold text-brownText">{institution.institutionName}</p>
+            <p className="text-gray-700">{institution.institutionAddress}</p>
           </div>
           <IconComponent
             name="pencil"
@@ -41,11 +41,11 @@ export function RoomContainer({ roomList, institution, handleTagClick }: Props) 
         <li key={item.id} className="flex gap-[6px] items-center">
           <div
             onClick={() => handleTagClick(item.propertyAddress, item.propertyName)}
-            className={`px-[6px] py-[2px] rounded-sm border border-black cursor-pointer w-fit text-[12px] bg-black text-white font-semibold leading-tight`}
+            className={`px-[6px] py-[2px] rounded-full border border-black cursor-pointer w-fit text-[12px] bg-black text-white font-semibold leading-tight`}
           >
             {item.propertyName}
           </div>
-          <p className="text-sm">{item.propertyAddress}</p>
+          <p className="text-sm font-semibold ">{item.propertyAddress}</p>
         </li>
       ))}
     </ul>

--- a/src/lib/zodSchema.ts
+++ b/src/lib/zodSchema.ts
@@ -7,7 +7,7 @@ export const createRoomZodSchema = z.object({
     .trim()
     .min(1, { message: '상세 주소는 필수입니다.' })
     .max(20, { message: '상세 주소는 최대 20글자까지만 가능합니다.' }),
-  nickName: z.string().trim().max(20, { message: '매물 이름은 최대 20글자까지만 가능합니다.' }),
+  nickName: z.string().trim().max(13, { message: '매물 이름은 최대 13글자까지만 가능합니다.' }), // 공백 포함 13자
 });
 
 export const roomInfoZodSchema = z.object({

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,6 +9,7 @@ import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import { useEffect } from 'react';
 import { useAuthStore } from '@/store/authStore';
+import KakaoScript from '@/components/Layout/KakaoScript';
 
 const queryClient = new QueryClient();
 
@@ -35,6 +36,7 @@ export default function App({ Component, pageProps }: AppProps) {
           <Toast />
           <Modal />
         </Layout>
+        <KakaoScript />
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>
     </>

--- a/src/pages/share/index.tsx
+++ b/src/pages/share/index.tsx
@@ -1,0 +1,94 @@
+import Button from '@/components/Button/CustomButton';
+import ShareCard from '@/components/DashBoard/ShareCard';
+import Dropdown from '@/components/Dropdown';
+import Header from '@/components/Layout/Header';
+import { mockHouserData } from '@/data/mockHouseData';
+import { Property } from '@/types';
+import { useEffect, useState } from 'react';
+
+const DROPDOWN_OPTION = ['최신순', '입주 빠른 순'];
+
+declare global {
+  interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Kakao: any;
+  }
+}
+
+export default function Home() {
+  const [propertyList, setPropertyList] = useState<Property[]>([]);
+  const [checkedList, setCheckedList] = useState<Property[]>([]);
+
+  const handleCheckList = (property: Property) => {
+    setCheckedList((prev) =>
+      prev.find((item) => item.id === property.id)
+        ? prev.filter((item) => item.id !== property.id)
+        : [...prev, property],
+    );
+  };
+
+  const shareKakao = () => {
+    const { Kakao } = window;
+
+    const ids = checkedList.map((item) => item.id).join(',');
+    const url = `${process.env.NEXT_PUBLIC_BASE_URL}/view?ids=${ids}`;
+
+    Kakao.Share.sendDefault({
+      objectType: 'feed',
+      content: {
+        title: '집 좀 같이 봐줘요!',
+        description: `내가 살 집에 대한 피드백을 주세요!`,
+        imageUrl: checkedList[0].propertyImages[0]?.imageUrl || '', // ✅ 안전하게 접근
+        link: {
+          mobileWebUrl: url,
+          webUrl: url, // ✅ 모바일+웹 둘 다
+        },
+      },
+      buttons: [
+        {
+          title: '집 같이 보기',
+          link: {
+            mobileWebUrl: url,
+            webUrl: url, // ✅
+          },
+        },
+      ],
+    });
+  };
+
+  useEffect(() => {
+    setPropertyList(mockHouserData);
+  }, []);
+
+  return (
+    <div className="h-full flex flex-col bg-[#F6F5F2] relative">
+      <Header type={1} title="공유하기" />
+      <p className="text-gray-700 text-sm text-center">공유할 매물을 선택해주세요</p>
+      <div className="flex flex-col px-5 py-2 gap-2 mb-20">
+        <div className="flex w-full justify-between items-center">
+          <p className="text-gray-500 text-[14px]">전체 {checkedList.length}</p>
+          <Dropdown options={DROPDOWN_OPTION} type="select" selectedOption="최신순" />
+        </div>
+        <ul className="flex flex-col gap-4">
+          {propertyList.map((property) => (
+            <li key={property.id}>
+              <ShareCard
+                info={property}
+                checked={checkedList.some((item) => item.id === property.id)}
+                onChange={handleCheckList}
+              />
+            </li>
+          ))}
+        </ul>
+      </div>
+      {checkedList.length > 0 && (
+        <div className="fixed bottom-0 left-1/2 w-full z-50 max-w-[428px] -translate-x-1/2 bg-primary flex flex-col">
+          <div className="absolute -top-10 left-0 w-full h-10 bg-gradient-to-b from-transparent to-primary" />
+          <div className="flex flex-col items-center gap-2 py-6 px-5">
+            <Button label="공유" className="w-full" onClick={shareKakao} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/view/index.tsx
+++ b/src/pages/view/index.tsx
@@ -1,5 +1,4 @@
 import HouseCard from '@/components/DashBoard/HouseCard';
-import ShareCard from '@/components/DashBoard/ShareCard';
 import Dropdown from '@/components/Dropdown';
 import Header from '@/components/Layout/Header';
 import { mockHouserData } from '@/data/mockHouseData';

--- a/src/pages/view/index.tsx
+++ b/src/pages/view/index.tsx
@@ -1,0 +1,43 @@
+import HouseCard from '@/components/DashBoard/HouseCard';
+import ShareCard from '@/components/DashBoard/ShareCard';
+import Dropdown from '@/components/Dropdown';
+import Header from '@/components/Layout/Header';
+import { mockHouserData } from '@/data/mockHouseData';
+import { Property } from '@/types';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+const DROPDOWN_OPTION = ['최신순', '입주 빠른 순'];
+
+export default function Home() {
+  const searchParams = useSearchParams();
+  const ids = searchParams.get('ids');
+  const [propertyList, setPropertyList] = useState<Property[]>([]);
+
+  useEffect(() => {
+    if (!ids) return;
+    const idArray = ids.split(',').map((id) => id.trim());
+    const filteredData = idArray
+      .map((id) => mockHouserData.find((item) => item.id === Number(id)))
+      .filter((item): item is Property => item !== undefined);
+    setPropertyList(filteredData);
+  }, [ids]);
+
+  return (
+    <div className="flex flex-col px-5 py-2 gap-2 mb-20">
+      <Header type={7} title="공유받은 매물" />
+
+      <div className="flex w-full justify-between items-center">
+        <p className="text-gray-500 text-[14px]">전체 {propertyList.length}</p>
+        <Dropdown options={DROPDOWN_OPTION} type="select" selectedOption="최신순" />
+      </div>
+      <ul className="flex flex-col gap-4">
+        {propertyList.map((item) => (
+          <li key={item.id}>
+            <HouseCard info={item} isShared />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
### 🔎 작업 내용

- [x] 헤더 공유 버튼 클릭시 공유 페이지로 이동합니다.
- [x] 공유할 매물을 선택하고, 공유버튼을 누르면 searchparams로 해당 매물 id가 전달됩니다.
- [x] 공유받은 페이지는 view 전용 페이지로 상호작용되지 않고 보는 것만 가능합니다. 지금은 mock에서 id값 찾아서 filter하고 있는데 나중에 서버에 요청을 보낼때 어떻게 해야할지 고민해봐야 할듯 최대 공유 갯수를 정하는게 좋을듯
- [x] 지도 관련 스타일링 수정