### PR TITLE
fix: 고정 리스트 로컬 스토리지에서 매물 데이터로 교체

### DIFF
--- a/src/components/DashBoard/HouseCard.tsx
+++ b/src/components/DashBoard/HouseCard.tsx
@@ -46,7 +46,9 @@ export default function HouseCard({ info, onDelete, onAdd, isFixed, isShared }: 
         <h1 className="font-bold text-lg">{info.propertyName}</h1>
         {!isShared && (
           <div className="flex gap-5">
-            {isFixed && <IconComponent name="pin" width={20} height={20} />}
+            {isFixed && (
+              <IconComponent name="pin" width={20} height={20} className="cursor-pointer" />
+            )}
             <Dropdown
               options={isFixed ? cancelOptionMenuList : defaultMenuList}
               type="meatball"

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -6,6 +6,7 @@ interface HeaderProps {
   type: 1 | 2 | 3 | 4 | 5 | 6 | 7;
   title: string;
   addAction?: () => void;
+  isFixed?: boolean;
 }
 
 // type 형태
@@ -19,7 +20,7 @@ interface HeaderProps {
 
 const ROOM_DETAIL_OPTION = ['매물 정보 수정', '사진 수정', '삭제'];
 
-export default function Header({ type, title, addAction }: HeaderProps) {
+export default function Header({ type, title, addAction, isFixed }: HeaderProps) {
   const router = useRouter();
   const roomDeatilhandleSelect = (option: string) => {
     switch (option) {
@@ -91,7 +92,9 @@ export default function Header({ type, title, addAction }: HeaderProps) {
               <h1 className="text-b-20 text-start">{title}</h1>
             </div>
             <div className="flex gap-3">
-              <IconComponent name="pin" width={24} height={24} className="cursor-pointer" />
+              {isFixed && (
+                <IconComponent name="pin" width={24} height={24} className="cursor-pointer" />
+              )}
               <IconComponent name="share" width={16} height={16} className="cursor-pointer" />
               <Dropdown
                 options={ROOM_DETAIL_OPTION}

--- a/src/data/mockHouseData.ts
+++ b/src/data/mockHouseData.ts
@@ -26,6 +26,7 @@ export const mockHouserData: Property[] = [
         priority: 2,
       },
     ],
+    isBookmarked: false,
   },
   {
     id: 6,
@@ -38,6 +39,7 @@ export const mockHouserData: Property[] = [
     propertyAddress: '서울특별시 성동구 성수동1가 656-1887',
     propertyDetailedAddress: '101동 1203호',
     propertyImages: [],
+    isBookmarked: false,
   },
   {
     id: 1,
@@ -50,6 +52,7 @@ export const mockHouserData: Property[] = [
     propertyAddress: '서울 강남구 역삼동 831-11',
     propertyDetailedAddress: '101동 1203호',
     propertyImages: [],
+    isBookmarked: false,
   },
   {
     id: 5,
@@ -62,6 +65,7 @@ export const mockHouserData: Property[] = [
     propertyAddress: '서울 서초구 서초동 1321-7',
     propertyDetailedAddress: '101동 1203호',
     propertyImages: [],
+    isBookmarked: false,
   },
   {
     id: 2,
@@ -74,6 +78,7 @@ export const mockHouserData: Property[] = [
     propertyAddress: '서울특별시 서초구 서초동 1316-5',
     propertyDetailedAddress: '101동 1203호',
     propertyImages: [],
+    isBookmarked: true,
   },
   {
     id: 3,
@@ -86,6 +91,7 @@ export const mockHouserData: Property[] = [
     propertyAddress: '서울특별시 서초구 서초동 1328-11',
     propertyDetailedAddress: '101동 1203호',
     propertyImages: [],
+    isBookmarked: true,
   },
 ];
 

--- a/src/pages/details/[id]/index.tsx
+++ b/src/pages/details/[id]/index.tsx
@@ -151,7 +151,7 @@ export default function ChecklistDetailPage() {
 
   return (
     <div className="h-full flex flex-col bg-[#F6F5F2] relative">
-      <Header type={3} title={propertyData.propertyName} />
+      <Header type={3} title={propertyData.propertyName} isFixed={propertyData.isBookmarked} />
       {isEdit && <EditButtonContainer onClick={() => setIsEdit(false)} />}
       <div className="w-full h-[202px] relative">
         <Swiper

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,51 +7,22 @@ import { useEffect, useState } from 'react';
 const DROPDOWN_OPTION = ['최신순', '입주 빠른 순'];
 
 export default function Home() {
-  const [fixedList, setFixedList] = useState<number[]>([]);
+  const [fixedList, setFixedList] = useState<Property[]>([]);
   const [propertyList, setPropertyList] = useState<Property[]>([]);
 
-  const fixedItems = propertyList.filter((item) => fixedList.includes(item.id)); // 고정된 리스트
-  const nonFixedItems = propertyList.filter((item) => !fixedList.includes(item.id)); // 고정되지 않은 리스트
+  const addFixedList = (id: number) => {
+    console.log('add', id);
+  };
 
   const deleteFixedList = (id: number) => {
-    setFixedList((prev) => [...prev, id]);
-    const localData = localStorage.getItem('property');
-    let existingData: number[] = [];
-    if (localData) {
-      existingData = JSON.parse(localData);
-      const newList = existingData.filter((item) => item !== id);
-      setFixedList(newList);
-      localStorage.setItem('property', JSON.stringify(newList));
-    }
-  };
-
-  const addFixedList = (id: number) => {
-    const localData = localStorage.getItem('property');
-    let existingData: number[] = [];
-    if (localData) {
-      existingData = JSON.parse(localData);
-      const addList = [...existingData, id];
-      localStorage.setItem('property', JSON.stringify(addList));
-    } else {
-      const addList = [id];
-      localStorage.setItem('property', JSON.stringify(addList));
-    }
-    setFixedList((prev) => [...prev, id]);
+    console.log('delete', id);
   };
 
   useEffect(() => {
-    const localData = localStorage.getItem('property');
-    let storedIds: number[] = [];
-    if (localData) {
-      storedIds = JSON.parse(localData);
-      if (storedIds.length > 0) {
-        setFixedList(storedIds);
-      }
-    }
-  }, []);
-
-  useEffect(() => {
-    setPropertyList(mockHouserData);
+    const bookmarkData = mockHouserData.filter((item) => item.isBookmarked); // 북마크 데이터
+    const normalData = mockHouserData.filter((item) => !item.isBookmarked); // 일반 데이터
+    setFixedList(bookmarkData);
+    setPropertyList(normalData);
   }, []);
 
   return (
@@ -61,12 +32,12 @@ export default function Home() {
         <Dropdown options={DROPDOWN_OPTION} type="select" selectedOption="최신순" />
       </div>
       <ul className="flex flex-col gap-4">
-        {fixedItems.map((item) => (
+        {fixedList.map((item) => (
           <li key={item.id}>
             <HouseCard info={item} onAdd={addFixedList} onDelete={deleteFixedList} isFixed />
           </li>
         ))}
-        {nonFixedItems.map((item) => (
+        {propertyList.map((item) => (
           <li key={item.id}>
             <HouseCard
               info={item}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,6 +36,7 @@ export interface Property {
   propertyAddress: string;
   propertyDetailedAddress: string;
   propertyImages: PropertyImage[];
+  isBookmarked: boolean;
 }
 
 export interface Institution {


### PR DESCRIPTION
### 🔎 작업 내용

- [x] 로컬스토리지로 관리하던 고정 리스트 수정했습니다.
- [ ] 커스텀 훅으로 리액트 쿼리 다루도록 하고, mutate후에 revalidation해주는게 나을듯합니다. 두개 데이터가 별도로 분리되서 어쩔수 없긴 하지만 사용성이 안좋을것 같은데 상태로 관리해주는게 나을지도...어차피 두개 데이터 리스트 상태는 한 컴포넌트에서 하니까?

### 📸 스크린샷

### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항
