### PR TITLE
feat: 지도 페이지 목록 버튼 및 모달 추가

### DIFF
--- a/public/icons/hanburger.svg
+++ b/public/icons/hanburger.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="10" viewBox="0 0 14 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.6665 5H12.3332M1.6665 1H12.3332M1.6665 9H12.3332" stroke="#23262A" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -246,7 +246,7 @@ export function Map({ roomList, institution, settingMapObject, handleMarkerClick
     <div className="relative pt-10">
       <div id="map" className="w-full h-[calc(100vh-110px)]" />
       <div
-        className="absolute w-8 h-8 bottom-5 right-5 bg-white z-50 rounded-full cursor-pointer"
+        className="absolute w-8 h-8 bottom-5 right-5 bg-white z-20 rounded-full cursor-pointer"
         onClick={moveCurrentPosition}
       />
     </div>

--- a/src/components/map/RoomContainer.tsx
+++ b/src/components/map/RoomContainer.tsx
@@ -1,15 +1,14 @@
-import { Institution, Property } from '@/types';
+import { Institution } from '@/types';
 import IconComponent from '../Asset/Icon';
 import { useRouter } from 'next/navigation';
 import CreateInstitutionButton from './CreateInstitutionButton';
 
 interface Props {
-  roomList: Property[];
   institution?: Institution;
   handleTagClick: (address: string, name: string) => Promise<void>;
 }
 
-export function RoomContainer({ roomList, institution, handleTagClick }: Props) {
+export function RoomContainer({ institution, handleTagClick }: Props) {
   const router = useRouter();
 
   return (
@@ -37,17 +36,6 @@ export function RoomContainer({ roomList, institution, handleTagClick }: Props) 
       ) : (
         <CreateInstitutionButton />
       )}
-      {roomList.map((item) => (
-        <li key={item.id} className="flex gap-[6px] items-center">
-          <div
-            onClick={() => handleTagClick(item.propertyAddress, item.propertyName)}
-            className={`px-[6px] py-[2px] rounded-full border border-black cursor-pointer w-fit text-[12px] bg-black text-white font-semibold leading-tight`}
-          >
-            {item.propertyName}
-          </div>
-          <p className="text-sm font-semibold ">{item.propertyAddress}</p>
-        </li>
-      ))}
     </ul>
   );
 }

--- a/src/components/map/RoomFloatButton.tsx
+++ b/src/components/map/RoomFloatButton.tsx
@@ -1,0 +1,58 @@
+import { Property } from '@/types';
+import { useState } from 'react';
+import IconComponent from '../Asset/Icon';
+
+interface Props {
+  roomList: Property[];
+  handleTagClick: (address: string, name: string) => Promise<void>;
+}
+
+export default function RoomFloatButton({ roomList, handleTagClick }: Props) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleClickTag = (address: string, name: string) => {
+    setIsOpen(false);
+    handleTagClick(address, name);
+  };
+  return (
+    <div className="z-30 w-full flex flex-col items-center">
+      <div
+        className="absolute px-4 py-2 rounded-full border-2 bottom-11 border-black bg-white flex items-center gap-1.5 cursor-pointer"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <IconComponent width={16} height={16} name="hamburger" />
+        <p className="font-semibold text-gray-800">목록보기</p>
+      </div>
+      {isOpen && (
+        <div className="absolute bottom-0 bg-white w-full flex flex-col p-5 pb-0 gap-3 rounded-t-xl border border-gray-300">
+          <div className="flex justify-between items-center h-6">
+            <p className="font-semibold text-base">목록</p>
+            <IconComponent
+              name="close"
+              width={10}
+              height={10}
+              onClick={() => setIsOpen(false)}
+              className="cursor-pointer"
+            />
+          </div>
+          <ul className="gap-1.5 flex flex-col max-h-[186px] overflow-y-auto pb-5">
+            {roomList.map((item) => (
+              <li
+                onClick={() => handleClickTag(item.propertyAddress, item.propertyName)}
+                key={item.id}
+                className="flex gap-[6px] items-center px-2 py-[11px] rounded-lg border-gray-300 border cursor-pointer"
+              >
+                <div
+                  className={`px-[6px] py-[2px] rounded-full border border-black  w-fit text-[12px] bg-black text-white font-semibold leading-tight`}
+                >
+                  {item.propertyName}
+                </div>
+                <p className="text-sm font-semibold ">{item.propertyAddress}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/constants/asset.tsx
+++ b/src/constants/asset.tsx
@@ -31,4 +31,5 @@ export const ICONS = {
   yellowCheck: 'icons/yellow-check.svg',
   logo: 'icons/logo.svg',
   chevronRight: 'icons/chevron-right.svg',
+  hamburger: 'icons/hanburger.svg',
 };

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -5,6 +5,7 @@ import Header from '@/components/Layout/Header';
 import { mockHouserData, mockInstitutionData } from '@/data/mockHouseData';
 import { RoomContainer } from '@/components/map/RoomContainer';
 import { Map } from '@/components/map/Map';
+import RoomFloatButton from '@/components/map/RoomFloatButton';
 
 export interface ModalContent {
   address: string;
@@ -48,9 +49,9 @@ export default function Page() {
     <div className="relative flex flex-col justify-center w-full">
       <div className="flex flex-col absolute top-0 right-0 left-0 z-10 bg-primary">
         <Header type={5} title="지도" />
-        <div className="p-5">
+        <div className="px-5">
           <RoomContainer
-            roomList={mockHouserData}
+            // roomList={mockHouserData}
             handleTagClick={handleTagClick}
             institution={mockInstitutionData}
           />
@@ -69,6 +70,7 @@ export default function Page() {
           closeModal={closeModal}
         />
       )}
+      <RoomFloatButton roomList={mockHouserData} handleTagClick={handleTagClick} />
     </div>
   );
 }


### PR DESCRIPTION
### 🔎 작업 내용

- [x] 지도 페이지 목록 버튼 추가

### 📸 스크린샷

<img width="629" alt="스크린샷 2025-05-06 오후 11 51 52" src="https://github.com/user-attachments/assets/0c03f3d4-5d8c-4f5b-aada-8fd9d7b5a73a" />
<img width="629" alt="스크린샷 2025-05-06 오후 11 51 56" src="https://github.com/user-attachments/assets/f90da037-5c4a-4874-a3f4-c7ca7498247e" />


### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항
